### PR TITLE
Correct dynamic shuffling example

### DIFF
--- a/src/jekyll/running-on-kubernetes.md
+++ b/src/jekyll/running-on-kubernetes.md
@@ -292,8 +292,8 @@ the command may then look like the following:
       --master k8s://<k8s-master>:<port> \
       --kubernetes-namespace default \
       --conf spark.app.name=group-by-test \
-      --conf spark.kubernetes.driver.docker.image=kubespark/spark-driver:latest \
-      --conf spark.kubernetes.executor.docker.image=kubespark/spark-executor:latest \
+      --conf spark.kubernetes.driver.docker.image=kubespark/spark-driver:v2.2.0-kubernetes-0.4.0 \
+      --conf spark.kubernetes.executor.docker.image=kubespark/spark-executor:v2.2.0-kubernetes-0.4.0 \
       --conf spark.dynamicAllocation.enabled=true \
       --conf spark.shuffle.service.enabled=true \
       --conf spark.kubernetes.shuffle.namespace=default \


### PR DESCRIPTION
The docs for dynamic shuffling are not working the referenced docker image doesn't exist:

```bash
docker pull kubespark/spark-driver:latest
Error response from daemon: manifest for kubespark/spark-driver:latest not found
```

This results in the following error:

```bash
    Optional:    false
QoS Class:       Burstable
Node-Selectors:  <none>
Tolerations:     node.alpha.kubernetes.io/notReady:NoExecute for 300s
                 node.alpha.kubernetes.io/unreachable:NoExecute for 300s
Events:
  Type     Reason                 Age                  From                                                   Message
  ----     ------                 ----                 ----                                                   -------
  Normal   Scheduled              36m                  default-scheduler                                      Successfully assigned group-by-test-1508830761433-driver to gke-big-data-demo-default-pool-cbb0305a-skzj
  Normal   SuccessfulMountVolume  36m                  kubelet, gke-big-data-demo-default-pool-cbb0305a-skzj  MountVolume.SetUp succeeded for volume "default-token-fs5zk"
  Normal   Pulling                4m (x11 over 36m)    kubelet, gke-big-data-demo-default-pool-cbb0305a-skzj  pulling image "kubespark/spark-driver:latest"
  Warning  Failed                 4m (x11 over 36m)    kubelet, gke-big-data-demo-default-pool-cbb0305a-skzj  Failed to pull image "kubespark/spark-driver:latest": rpc error: code = 2 desc = Error response from daemon: {"message":"manifest for kubespark/spark-driver:latest not found"}
  Warning  FailedSync             16s (x161 over 36m)  kubelet, gke-big-data-demo-default-pool-cbb0305a-skzj  Error syncing pod
  Normal   BackOff                16s (x150 over 36m)  kubelet, gke-big-data-demo-default-pool-cbb0305a-skzj  Back-off pulling image "kubespark/spark-driver:latest"
```

If you adjust the docker image tag everything works as expected:

```bash
$ kubectl get po --show-all          
NAME                                 READY     STATUS      RESTARTS   AGE
group-by-test-1508833005822-driver   0/1       Completed   0          56s
shuffle-cjcsw                        1/1       Running     0          39m
shuffle-hhqj3                        1/1       Running     0          39m
shuffle-kl4d0                        1/1       Running     0          39m
shuffle-vkcxz                        1/1       Running     0          39m
```